### PR TITLE
Devolver un error cuando el token sea inválido

### DIFF
--- a/lib/helpers/token_helper.ex
+++ b/lib/helpers/token_helper.ex
@@ -30,14 +30,11 @@ defmodule ResuelveAuth.Helpers.TokenHelper do
   """
   @spec verify_token(String.t, String.t) :: tuple
   def verify_token(token, secret) do
-    [data, sign] = String.split(token, ".")
-    valid_sign = sign_data(data, secret)
-
-    case String.equivalent?(sign, valid_sign) do
-      true ->
-        parse_token_data(data)
-      false ->
-        {:error, "Unauthorized"}
+    with [data, sign] <- String.split(token, "."),
+         true <- String.equivalent?(sign, sign_data(data, secret)) do
+      parse_token_data(data)
+    else
+      _ -> {:error, "Unauthorized"}
     end
   end
 

--- a/test/resuelve_auth_test.exs
+++ b/test/resuelve_auth_test.exs
@@ -28,4 +28,10 @@ defmodule ResuelveAuthTest do
         "session" => "session",
         "timestamp" => "timestamp"}}
   end
+
+  test "Verify invalid token" do
+    assert TokenHelper.verify_token("invalid_token", "secret") == {
+      :error,
+      "Unauthorized"}
+  end
 end


### PR DESCRIPTION
Coyote dos tipos de tokens, cuando el token no contiene un punto el plug no devuelve el error