### PR TITLE
Agrega soporte para tener una función para obtener el secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,29 @@ Agregar el Plug a un pipeline, siguiendo las [guías para crear bibliotecas en E
 pipeline :api_auth do
   ...
   options = [
-       secret: "secret", 
+       secret: "secret",
+  		limit_time: 4,
+  		handler: MyApp.AuthHandler
+  		]
+  plug ResuelveAuth.AuthPlug, options
+end
+```
+
+También se puede definir una función que se encargará de obtener el secret en tiempo de ejecución, esto para evitar que se asigne un valor `nil` al plug durante la compilación.
+
+Teniendo un módulo que se encargue de obtner el `secret` de algún lugar.
+
+```elixir
+defmodule Vault do
+  def get_secret, do: "super secret"
+end
+```
+
+```elixir
+pipeline :api_auth do
+  ...
+  options = [
+       secret: &Vault.get_secret/0,
   		limit_time: 4,
   		handler: MyApp.AuthHandler
   		]

--- a/lib/auth_plug.ex
+++ b/lib/auth_plug.ex
@@ -73,18 +73,11 @@ defmodule ResuelveAuth.AuthPlug do
 
   @impl Plug
   def init(options) do
-    {secret, options} = Keyword.pop(options, :secret)
+    secret = infer_secret(options[:secret])
 
-    secret =
-      if is_function(secret) do
-        apply(secret, [])
-      else
-        secret
-      end
-
-    options = Keyword.put(options, :secret, secret)
-
-    Keyword.merge(@default, options)
+    @default
+    |> Keyword.merge(options)
+    |> Keyword.merge(secret: secret)
   end
 
   @impl Plug
@@ -100,4 +93,8 @@ defmodule ResuelveAuth.AuthPlug do
         options[:handler].errors(conn, "Unauthorized")
     end
   end
+
+  @spec infer_secret(String.t() | function) :: String.t()
+  defp infer_secret(value) when is_binary(value), do: value
+  defp infer_secret(value) when is_function(value), do: apply(value, [])
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ResuelveAuth.Mixfile do
   use Mix.Project
 
-  @version "1.3.0"
+  @version "1.4.0"
 
   def project do
     [

--- a/test/auth_plug_test.exs
+++ b/test/auth_plug_test.exs
@@ -45,6 +45,31 @@ defmodule ResuelveAuth.AuthPlugTest do
     assert token_map == response_map
   end
 
+  test "access granted when using a function to get secret value" do
+    defmodule MyApp do
+      def get_secret, do: "secret"
+    end
+
+    %{token: token, jwt: jwt} = build_token("AuthPlugTest_App")
+    options = AuthPlug.init(secret: &MyApp.get_secret/0)
+
+    conn =
+      conn(:get, "/", "")
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "#{jwt}")
+      |> AuthPlug.call(options)
+
+    %{assigns: %{session: response}} = conn
+    token_map = Map.from_struct(token)
+
+    response_map =
+      response
+      |> cast()
+      |> Map.delete(:time)
+
+    assert token_map == response_map
+  end
+
   test "bad header" do
     options = [limit_time: 4, handler: ResuelveAuth.Sample.AuthHandler]
 


### PR DESCRIPTION
Debido a que el plug se define en un router, el valor del secret es
asignado al módulo en tiempo de compilación por lo que no se puede
modificar usando una variable de entorno o algún otro método de
gestión de secretos