### PR TITLE
Expiration in TokenData

### DIFF
--- a/lib/helpers/token_helper.ex
+++ b/lib/helpers/token_helper.ex
@@ -28,9 +28,9 @@ defmodule ResuelveAuth.Helpers.TokenHelper do
      iex> options = [secret: "secret", limit_time: 4]
      iex> alias ResuelveAuth.Helpers.TokenHelper
      iex> token = TokenHelper.create_token(data, options)
-     "eyJ0aW1lc3RhbXAiOjE1NzI2NTYxNTUxMzUsInNlc3Npb24iOm51bGwsInNlcnZpY2UiOiJteS1hcGkiLCJyb2xlIjoic2VydmljZSIsIm1ldGEiOm51bGx9.1E1FA5A03B62DB5E0E5C5627D578E4ABBD1E83EFBFF72907428D0C95DC491394"
+     "eyJ0aW1lc3RhbXAiOjE1NzI2NTYxNTUxMzUsInNlc3Npb24iOm51bGwsInNlcnZpY2UiOiJteS1hcGkiLCJyb2xlIjoic2VydmljZSIsIm1ldGEiOm51bGwsImV4cGlyYXRpb24iOjg2NDAwMDAwfQ==.0BFEF9F51F0C65B7E190EF311D5B01D086014542CD13B04BEF1173EAAC0F07B8"
      iex> String.length(token)
-     185
+     217
 
   ```
 

--- a/lib/token_data.ex
+++ b/lib/token_data.ex
@@ -6,7 +6,7 @@ defmodule ResuelveAuth.TokenData do
   alias ResuelveAuth.Utils.Secret
 
   # It's used by NuLogin to manage the token's TTL
-  @day_in_ms 86400000
+  @day_in_ms 86_400_000
 
   defstruct [:service, :role, :session, :timestamp, :meta, {:expiration, @day_in_ms}]
 

--- a/lib/token_data.ex
+++ b/lib/token_data.ex
@@ -5,6 +5,7 @@ defmodule ResuelveAuth.TokenData do
 
   alias ResuelveAuth.Utils.Secret
 
+  # It's used by NuLogin to manage the token's TTL
   @day_in_ms 86400000
 
   defstruct [:service, :role, :session, :timestamp, :meta, {:expiration, @day_in_ms}]

--- a/lib/token_data.ex
+++ b/lib/token_data.ex
@@ -5,7 +5,9 @@ defmodule ResuelveAuth.TokenData do
 
   alias ResuelveAuth.Utils.Secret
 
-  defstruct [:service, :role, :session, :timestamp, :meta]
+  @day_in_ms 86400000
+
+  defstruct [:service, :role, :session, :timestamp, :meta, {:expiration, @day_in_ms}]
 
   @doc """
   Convert token to valid data or return an error.

--- a/test/helpers/token_helper_test.exs
+++ b/test/helpers/token_helper_test.exs
@@ -20,7 +20,7 @@ defmodule ResuelveAuth.Helpers.TokenHelperTest do
       meta: "metadata"
     }
 
-    assert TokenHelper.create_token(token_data, @secret) == @token 
+    assert TokenHelper.create_token(token_data, @secret) == @token
   end
 
   test "validate token after build it" do

--- a/test/helpers/token_helper_test.exs
+++ b/test/helpers/token_helper_test.exs
@@ -9,8 +9,7 @@ defmodule ResuelveAuth.Helpers.TokenHelperTest do
   alias ResuelveAuth.TokenData
 
   @secret [secret: "secret", limit_time: 4]
-  @json "eyJ0aW1lc3RhbXAiOiJ0aW1lc3RhbXAiLCJzZXNzaW9uIjoic2Vzc2lvbiIsInNlcnZpY2UiOiJteV9zZXJ2aWNlIiwicm9sZSI6InJvbGUiLCJtZXRhIjoibWV0YWRhdGEifQ==."
-  @sign "B5DCF6F8352BEC7D59C521E29A10122EA79456C76394F104F05B6B8203DB4F4E"
+  @token "eyJ0aW1lc3RhbXAiOiJ0aW1lc3RhbXAiLCJzZXNzaW9uIjoic2Vzc2lvbiIsInNlcnZpY2UiOiJteV9zZXJ2aWNlIiwicm9sZSI6InJvbGUiLCJtZXRhIjoibWV0YWRhdGEiLCJleHBpcmF0aW9uIjo4NjQwMDAwMH0=.876C688998BACBC78FBAF6821AB579ACB8A8A8FCD906BC833CC438D19DD0B5EA"
 
   test "generate new token" do
     token_data = %TokenData{
@@ -21,7 +20,7 @@ defmodule ResuelveAuth.Helpers.TokenHelperTest do
       meta: "metadata"
     }
 
-    assert TokenHelper.create_token(token_data, @secret) == @json <> @sign
+    assert TokenHelper.create_token(token_data, @secret) == @token 
   end
 
   test "validate token after build it" do
@@ -41,7 +40,7 @@ defmodule ResuelveAuth.Helpers.TokenHelperTest do
   end
 
   test "verify token when timestamp is string" do
-    result = TokenHelper.verify_token(@json <> @sign, @secret)
+    result = TokenHelper.verify_token(@token, @secret)
     assert {:error, :invalid_unix_time} == result
   end
 

--- a/test/utils/secret_test.exs
+++ b/test/utils/secret_test.exs
@@ -10,7 +10,7 @@ defmodule ResuelveAuth.Utils.SecretTest do
     service: "my-api",
     session: nil,
     timestamp: 1_594_039_006_911,
-    expiration: 86400000
+    expiration: 86_400_000
   }
 
   describe "[encode] " do

--- a/test/utils/secret_test.exs
+++ b/test/utils/secret_test.exs
@@ -9,7 +9,8 @@ defmodule ResuelveAuth.Utils.SecretTest do
     role: "user",
     service: "my-api",
     session: nil,
-    timestamp: 1_594_039_006_911
+    timestamp: 1_594_039_006_911,
+    expiration: 86400000
   }
 
   describe "[encode] " do
@@ -17,7 +18,7 @@ defmodule ResuelveAuth.Utils.SecretTest do
       {:ok, result} = Secret.encode(@token)
 
       assert result ==
-               ~s({"timestamp":1594039006911,"session":null,"service":"my-api","role":"user","meta":"metadata"})
+        ~s({"timestamp":1594039006911,"session":null,"service":"my-api","role":"user","meta":"metadata","expiration":86400000})
     end
 
     test "test valid results with encode64" do
@@ -27,7 +28,7 @@ defmodule ResuelveAuth.Utils.SecretTest do
         |> Secret.encode64()
 
       assert result ==
-               "eyJ0aW1lc3RhbXAiOjE1OTQwMzkwMDY5MTEsInNlc3Npb24iOm51bGwsInNlcnZpY2UiOiJteS1hcGkiLCJyb2xlIjoidXNlciIsIm1ldGEiOiJtZXRhZGF0YSJ9"
+        "eyJ0aW1lc3RhbXAiOjE1OTQwMzkwMDY5MTEsInNlc3Npb24iOm51bGwsInNlcnZpY2UiOiJteS1hcGkiLCJyb2xlIjoidXNlciIsIm1ldGEiOiJtZXRhZGF0YSIsImV4cGlyYXRpb24iOjg2NDAwMDAwfQ=="
     end
 
     test "test invalid keys" do


### PR DESCRIPTION
Adds the expiration field that Nulogin uses to manage the token's ttl  with a default value of 1 day