### PR TITLE
Add elixir1.12 with otp24 to matrix test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           - elixir_version: elixir:1.10-alpine
           # otp 23
           - elixir_version: elixir:1.11-alpine
+          # otp 24
+          - elixir_version: elixir:1.12-alpine
     runs-on: ubuntu-latest
     container: ${{ matrix.elixir_version }}
     steps:


### PR DESCRIPTION
In a previous commit a fix to support otp24 was added so we need to
run tests against this specific version as well