### PR TITLE
Allow configuring plug with Mix.Config

### DIFF
--- a/lib/auth_plug.ex
+++ b/lib/auth_plug.ex
@@ -2,36 +2,59 @@ defmodule ResuelveAuth.AuthPlug do
   @moduledoc """
   Plug for authentication using token signature verification.
 
+  ## Basic Usage
+
+  In your router, append the plug to a pipeline. Example:
+
+  ```elixir
+  defmodule MyApp.Router do
+    ...
+    pipeline :auth do
+      plug ResuelveAuth.AuthPlug
+    end
+    ...
+  end
+  ```
+
+  ## Configuration
+
+  Here's the list of options available:
+
   | Option  | Description | Default value |
   | ------- | ----------- | ------------- |
-  | limit_time | time in hours | 168 h (1 w) |
+  | limit_time | Token lifespan in hours | 168 (1 week) |
   | secret  | Secret key | empty  |
   | handler | Error handler function | ResuelveAuth.Sample.AuthHandler |
 
-  ## Example
+  ### Config Files
+
+  You can declare global or per environment configuration for the plug in your config files.
 
   ```elixir
-
-  # En el archivo router.ex
-  defmodule MyApi.Router do
-
-    # Using 10 hours as limit and default error handler
-    @options [secret: "my-secret-key", limit_time: 10]
-    use MyApi, :router
-
-    pipeline :auth do
-      plug ResuelveAuth.AuthPlug, @options
-    end
-
-    scope "/v1", MyApi do
-      pipe_through([:auth])
-      ..
-      post("/users/", UserController, :create)
-    end
-  end
-
+  # In config/{config|prod|dev|test|runtime}.exs
+  config :resuelve_auth,
+    secret: "my-secret-key",
+    limit_time: 24,
+    handler: MyApp.MyAuthHandler
   ```
 
+  ### Inline Options
+
+  You can also pass a keyword list of options to the plug declaration. This allows
+  to have multiple configurations.
+
+  ```elixir
+    pipeline :auth do
+      plug ResuelveAuth.AuthPlug, secret: "my-secret-key", ...
+    end
+  ```
+
+  Note: If you use environmental variables to set any inline configuration option,
+  you'll need to make sure those variables are available at compilation time since
+  they'll be used in a macro (your app's router). If you don't need multiple configs
+  per environment we recommend using `config/runtime.exs` file instead.
+
+  Inline configuration will override global and per-environment configuration.
   """
 
   import Plug.Conn
@@ -39,19 +62,22 @@ defmodule ResuelveAuth.AuthPlug do
 
   @behaviour Plug
 
-  @default [
+  @default_options [
     limit_time: 168,
     secret: "",
     handler: ResuelveAuth.Sample.AuthHandler
   ]
 
   @impl Plug
-  def init(options) do
-    Keyword.merge(@default, options)
-  end
+  def init(options), do: options
 
   @impl Plug
-  def call(%Plug.Conn{} = conn, options) do
+  def call(%Plug.Conn{} = conn, inline_options) do
+    options =
+      @default_options
+      |> Keyword.merge(Application.get_all_env(:resuelve_auth))
+      |> Keyword.merge(inline_options)
+
     with [token] <- get_req_header(conn, "authorization"),
          {:ok, data} <- TokenHelper.verify_token(token, options) do
       assign(conn, :session, data)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ResuelveAuth.Mixfile do
   use Mix.Project
 
-  @version "1.4.3"
+  @version "1.5.0"
 
   def project do
     [


### PR DESCRIPTION
- Allow configuring plug using Mix.Config module (`config :resuelve_auth, [options]`).
- Update README and documentation to reflect the new configuration approach.
- Improve grammar in README