### PR TITLE
Arregla problemas al publicar paquete hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plug to validate signed request.
 
 ```elixir
 def deps do
-  [{:resuelve_auth, "~> 1.4"}]
+  [{:resuelve_auth, "~> 1.5", organization: "resuelve"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,8 @@ defmodule ResuelveAuth.Mixfile do
 
   def package do
     [
+      name: "resuelve_auth",
+      organization: "resuelve",
       files: ~w(lib mix.exs README*),
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/resuelve/resuelve-auth-plug"}

--- a/mix.exs
+++ b/mix.exs
@@ -56,10 +56,10 @@ defmodule ResuelveAuth.Mixfile do
     [
       {:plug, "~> 1.8"},
       {:excoveralls, "~> 0.12", only: :test, override: true},
-      {:ex_doc, ">= 0.19.0", runtime: false, override: true},
-      {:earmark, "~> 1.3.0", override: true},
+      {:ex_doc, ">= 0.19.0", runtime: false},
+      {:earmark, "~> 1.3.0"},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
-      {:poison, "~> 3.1", override: true},
+      {:poison, "~> 3.1"},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]
   end


### PR DESCRIPTION
### Contexto

No se pudo publicar paquete hex mediante el comando `mix hex.publish` arrojando error `account not authorized for this action`. Esto se debe a que el owner del paquete `resuelve_auth` no es resuelve.

### Solución

Se utiliza `organization: "resuelve"`  al publicar el paquete, por contraparte en los proyectos donde se use esta dependencia debe usar también `organization: "resuelve` como se indica ahora en el README