### PR TITLE
la dependecia de ex_doc debe ser solo en desarrollo

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule ResuelveAuth.Mixfile do
     [
       {:plug, "~> 1.8"},
       {:excoveralls, "~> 0.12", only: :test, override: true},
-      {:ex_doc, ">= 0.19.0", runtime: false},
+      {:ex_doc, ">= 0.19.0", only: :dev, runtime: false},
       {:earmark, "~> 1.3.0"},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:poison, "~> 3.1"},


### PR DESCRIPTION
`resuelve_auth` requiere `ex_doc` pero esta dependencia no está marcada correctamente como `only: :dev, runtime: false`, lo que causa errores de compilación cuando se intenta hacer `mix deps.get --only prod`.